### PR TITLE
docs(readme): update param names and types for credentials and token

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ import path from 'path'
 export const config = {
     // ...
     services: [['gmail', {
-        credentialsJsonPath: path.join(process.cwd(), './credentials.json'),
-        tokenJsonPath: join(process.cwd(), './token.json'),
+        credentials: path.join(process.cwd(), './credentials.json'),
+        token: join(process.cwd(), './token.json'),
         intervalSec: 10,
         timeoutSec: 60
     }]]
@@ -48,17 +48,17 @@ export const config = {
 
 ## Service Options
 
-### credentialsJsonPath
+### credentials
 Absolute path to a credentials JSON file.
 
-Type: `string`
+Type: `string | Credentials`
 
 Required: `true`
 
-### tokenJsonPath
+### token
 Absolute path to a token JSON file.
 
-Type: `string`
+Type: `string | Record<string, unknown>`
 
 Required: `true`
 


### PR DESCRIPTION
This PR updates the `README.md` to reflect recent changes introduced in [#510](https://github.com/webdriverio-community/wdio-gmail-service/pull/510) that were not yet reflected in the documentation.

### Changes
- **Renamed parameters:**
  - `credentialsJsonPath` → `credentials`
  - `tokenJsonPath` → `token`
- **Updated types:**
  - `credentials`: `string | Credentials`
  - `token`: `string | Record<string, unknown>`

These updates ensure the README aligns with the current implementation and helps avoid confusion for new users of the package.